### PR TITLE
added compatibility with django-storages[azure]

### DIFF
--- a/mdeditor/templates/markdown.html
+++ b/mdeditor/templates/markdown.html
@@ -66,7 +66,7 @@
                 })
             },
             syncScrolling: "single",
-            path: "{% static  'mdeditor/js/lib/' %}",
+            path: "{% static  'mdeditor/js/lib' %}" + "/",
             // theme
             theme : "{{ config.theme|safe }}",
             previewTheme : "{{ config.preview_theme|safe }}",

--- a/mdeditor/widgets.py
+++ b/mdeditor/widgets.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from django import forms
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
@@ -37,7 +37,7 @@ class MDEditorWidget(forms.Textarea):
         final_attrs = self.build_attrs(self.attrs, attrs, name=name)
         return mark_safe(render_to_string('markdown.html', {
             'final_attrs': flatatt(final_attrs),
-            'value': conditional_escape(force_text(value)),
+            'value': conditional_escape(force_str(value)),
             'id': final_attrs['id'],
             'config': self.config,
         }))


### PR DESCRIPTION
When using some custom storage backends for django, like django-storages, the response returned by the url() method of "static" may return without the slash at the end of the string. 

This happens for example with Azure storage, which does not accept files that end with "." or "/".
[https://django-storages.readthedocs.io/en/latest/backends/azure.html](url)

This simple change solves this problem, as it includes a slash after the call to "static" in markdown.html. 
Therefore, it is not necessary to make any other changes to editormd.js to ensure compatibility.