### PR TITLE
Fix: Preview Headings color in dark mode

### DIFF
--- a/mdeditor/templates/markdown.html
+++ b/mdeditor/templates/markdown.html
@@ -15,8 +15,8 @@
     .wmd-wrapper h4,
     .wmd-wrapper h5,
     .wmd-wrapper h6 {
-        background: #ffffff !important;
-        color: #000000 !important;
+        background: #ffffff;
+        color: #000000;
     }
     .wmd-wrapper h2,
     .wmd-wrapper h3,


### PR DESCRIPTION
When we enable dark mode for the editor, it makes the heading background white and because it was marked as important, we can't overwrite the CSS.