### PR TITLE
Added support for any language included as a static

### DIFF
--- a/mdeditor/templates/markdown.html
+++ b/mdeditor/templates/markdown.html
@@ -38,12 +38,10 @@
   <textarea {{ final_attrs|safe }}>{{ value }}</textarea>
 </div>
 
-{% if config.language == 'en' %}
-<script src="{% static 'mdeditor/languages/en.js' %}"></script>
-{% elif config.language == 'de' %}
-<script src="{% static 'mdeditor/languages/de.js' %}"></script>
-{% elif config.language == 'pt_BR' %}
-<script src="{% static 'mdeditor/languages/pt_BR.js' %}"></script>
+{% if config.language %}
+{% with 'mdeditor/languages/'|add:config.language|add:'.js' as language_url %}
+<script src="{% static language_url %}"></script>
+{% endwith %}
 {% endif %}
 <script type="text/javascript">
 


### PR DESCRIPTION
The spanish translations are added but can't be used currently. With this PR you can pass whatever to the languages. Even custom translations, by adding them to a file under `static/mdeditor/languages/`, as long as the name doesn't conflict.

For example, the following is a file named `my_app/static/mdeditor/languages/es_custom.js`:
<details><summary>es_custom.js</summary>

```js
(function () {
  var factory = function (exports) {
    var lang = {
      name: "es",
      description: "Editor Markdown en línea de código abierto.",
      tocTitle: "Índice",
      toolbar: {
        undo: "Deshacer (Ctrl+Z)",
        redo: "Rehacer (Ctrl+Y)",
        bold: "Negrita",
        del: "Tachado",
        italic: "Cursiva",
        quote: "Citar",
        ucwords: "Primera letra de las palabras en mayúsculas",
        uppercase: "Convertir la selección a mayúsculas",
        lowercase: "Convertir la selección a minúsculas",
        h1: "Título 1",
        h2: "Título 2",
        h3: "Título 3",
        h4: "Título 4",
        h5: "Título 5",
        h6: "Título 6",
        "list-ul": "Lista no ordenada",
        "list-ol": "Lista ordenada",
        hr: "Línea horizontal",
        link: "Enlace",
        "reference-link": "Referencia a enlace",
        image: "Imagen",
        code: "Código",
        "preformatted-text": "Texto preformateado / Bloque de código (Indentado por Tab)",
        "code-block": "Bloque de código (Multi-lenguaje)",
        table: "Tablas",
        datetime: "Fecha y hora",
        emoji: "Emoji",
        "html-entities": "Entidades HTML",
        pagebreak: "Salto de página",
        watch: "Observar",
        unwatch: "Dejar de observar",
        preview: "Vista previa HTML (Shift + ESC para salir)",
        fullscreen: "Pantalla completa (ESC para salir)",
        clear: "Borrar",
        search: "Buscar",
        help: "Ayuda",
        info: "Acerca de " + exports.title
      },
      buttons: {
        enter: "Aceptar",
        cancel: "Cancelar",
        close: "Cerrar"
      },
      dialog: {
        link: {
          title: "Enlace",
          url: "Dirección",
          urlTitle: "Título",
          urlEmpty: "Error: Introduzca la dirección del enlace."
        },
        referenceLink: {
          title: "Referencia a enlace",
          name: "Nombre",
          url: "Dirección",
          urlId: "ID",
          urlTitle: "Título",
          nameEmpty: "Error: El nombre no puede estar vacío.",
          idEmpty: "Error: Introduzca un ID.",
          urlEmpty: "Error: Introduzca una dirección URL."
        },
        image: {
          title: "Imagen",
          url: "Dirección",
          link: "Enlace",
          alt: "Título",
          uploadButton: "Cargar",
          imageURLEmpty: "Error: La dirección URL de la imagen no puede estar vacía.",
          uploadFileEmpty: "Error: ¡No se pueden cargar imágenes vacías!",
          formatNotAllowed: "Error: Sólo se pueden cargar archivos de imagen. Los formatos permitidos son:"
        },
        preformattedText: {
          title: "Texto preformateado / Código",
          emptyAlert: "Error: Introduzca el texto preformateado o el código.",
          placeholder: "Código...."
        },
        codeBlock: {
          title: "Bloque de código",
          selectLabel: "Lenguajes: ",
          selectDefaultText: "Selecciona un lenguaje...",
          otherLanguage: "Otros",
          unselectedLanguageAlert: "Error: Selecciona un lenguaje.",
          codeEmptyAlert: "Error: Introduce el código.",
          placeholder: "Código...."
        },
        htmlEntities: {
          title: "Entidades HTML"
        },
        help: {
          title: "Ayuda"
        }
      }
    };

    exports.defaults.lang = lang;
  };

  // CommonJS/Node.js
  if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
    module.exports = factory;
  }
  else if (typeof define === "function")  // AMD/CMD/Sea.js
  {
    if (define.amd) { // for Require.js

      define(["editormd"], function (editormd) {
        factory(editormd);
      });

    } else { // for Sea.js
      define(function (require) {
        var editormd = require("../editormd");
        factory(editormd);
      });
    }
  }
  else {
    factory(window.editormd);
  }

})();
```

</details>

By setting `MDEDITOR_CONFIGS["default"]["language"]` to `es_custom`. I can enjoy my custom translations with this change alone.

Thanks!